### PR TITLE
Weapon Components 

### DIFF
--- a/Content/Blueprints/BP_ComponentItem.uasset
+++ b/Content/Blueprints/BP_ComponentItem.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49e0e045d602e10236fb3875d0745b6fd1508bc7ecde80dd3bf261a4ace31869
+size 245431

--- a/Content/Blueprints/BP_WeaponItem.uasset
+++ b/Content/Blueprints/BP_WeaponItem.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a80618fae294da75eeece507c6948e7023008822edfaec6daa81d56e12b45a0a
-size 304032
+oid sha256:5928700ed966d720d0ca203312f33364dfb54e266116cec6d4dbd62862ae742b
+size 301021

--- a/Content/Blueprints/UI/WBP_Reload.uasset
+++ b/Content/Blueprints/UI/WBP_Reload.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49ac383dbed09042d982974f7ae2ca567a5f46bb2354d0c066779b4e327ffd17
-size 95027
+oid sha256:9849439094c565195e7e3f16b86da9f6f121cd98faa547b27136ff25e6cded77
+size 101165

--- a/Content/DataAssets/DA_TestComponent.uasset
+++ b/Content/DataAssets/DA_TestComponent.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2403fc663fb0d1b561b3b963c7f1cdfed2e8dbf4236e8820de3d63e5769da7f4
+oid sha256:4f452b619c1ece0ebd414abbb762f5aec22806955d44072015f5b4aea6edf6d6
 size 1436

--- a/Content/DataAssets/DA_TestComponent.uasset
+++ b/Content/DataAssets/DA_TestComponent.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f12aefebc15901e226cbffbc96954ef196ee5228dc112b2a5b05cc9b59edb8b0
-size 1634
+oid sha256:2403fc663fb0d1b561b3b963c7f1cdfed2e8dbf4236e8820de3d63e5769da7f4
+size 1436

--- a/Content/DataAssets/DA_TestComponent.uasset
+++ b/Content/DataAssets/DA_TestComponent.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f12aefebc15901e226cbffbc96954ef196ee5228dc112b2a5b05cc9b59edb8b0
+size 1634

--- a/Content/Maps/MainLevel.umap
+++ b/Content/Maps/MainLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ac5f5f0d65cdd6430b55e07d669ac35e5beea428127d062b5d3467be291b37f
-size 8624995
+oid sha256:cc29e8a7054dc418eb098edaa88194e7bb207e21b96ae39821f42ec4153c64d6
+size 8623842

--- a/Content/Maps/MainLevel.umap
+++ b/Content/Maps/MainLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82a6a3c98613f6122ebfe15367102b428cbd7c21f402f54e8edd0aa0ef97af42
-size 8624887
+oid sha256:7ac5f5f0d65cdd6430b55e07d669ac35e5beea428127d062b5d3467be291b37f
+size 8624995

--- a/Content/Maps/MainLevel_Components.umap
+++ b/Content/Maps/MainLevel_Components.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14fbf51b337c02f1af4d4884ce71329d89823de9c034a4ad00d9df0cf96c3500
-size 8622825
+oid sha256:9f619967d60d56640474aa975ebeed2f33e2946b36048070befc3a6dd4613e70
+size 8624000

--- a/Content/Maps/MainLevel_Components.umap
+++ b/Content/Maps/MainLevel_Components.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bb0d2755a2b379e77c1c3126ca3bc39170cc8b146ee0f5bf6d244403ca5ea13
+oid sha256:14fbf51b337c02f1af4d4884ce71329d89823de9c034a4ad00d9df0cf96c3500
 size 8622825

--- a/Content/Maps/MainLevel_Components.umap
+++ b/Content/Maps/MainLevel_Components.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bb0d2755a2b379e77c1c3126ca3bc39170cc8b146ee0f5bf6d244403ca5ea13
+size 8622825

--- a/Source/UntitledGame/Component.cpp
+++ b/Source/UntitledGame/Component.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Component.h"
+

--- a/Source/UntitledGame/Component.h
+++ b/Source/UntitledGame/Component.h
@@ -9,7 +9,7 @@
 UENUM(BlueprintType)
 enum class WeaponStat : uint8
 {
-	MaxAbilities,
+	MaxAbilities, // TODO: Components should not be able to modify MaxAbilities!
 	FireRate,
 	ReloadTime
 };

--- a/Source/UntitledGame/Component.h
+++ b/Source/UntitledGame/Component.h
@@ -1,0 +1,43 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataAsset.h"
+#include "Component.generated.h"
+
+UENUM(BlueprintType)
+enum class WeaponStat : uint8
+{
+	MaxAbilities,
+	FireRate,
+	ReloadTime
+};
+
+USTRUCT(BlueprintType)
+struct FStatModifier
+{
+	GENERATED_USTRUCT_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	WeaponStat Stat;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	float Modifier;
+};
+
+/**
+ *  Holds information about a generic component and the stats it modifies.
+ */
+UCLASS()
+class UNTITLEDGAME_API UComponent : public UDataAsset
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	FString Name;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	TArray<FStatModifier> Modifiers;
+};

--- a/Source/UntitledGame/Component.h
+++ b/Source/UntitledGame/Component.h
@@ -9,7 +9,7 @@
 UENUM(BlueprintType)
 enum class WeaponStat : uint8
 {
-	MaxAbilities, 
+	MaxAbilities,
 	FireRate,
 	ReloadTime
 };
@@ -17,7 +17,7 @@ enum class WeaponStat : uint8
 /**
  *  Holds information about a generic component and the stats it modifies.
  */
-UCLASS()
+UCLASS(BlueprintType)
 class UNTITLEDGAME_API UComponent : public UDataAsset
 {
 	GENERATED_BODY()

--- a/Source/UntitledGame/Component.h
+++ b/Source/UntitledGame/Component.h
@@ -9,7 +9,7 @@
 UENUM(BlueprintType)
 enum class WeaponStat : uint8
 {
-	MaxAbilities,
+	MaxAbilities, 
 	FireRate,
 	ReloadTime
 };

--- a/Source/UntitledGame/Component.h
+++ b/Source/UntitledGame/Component.h
@@ -14,18 +14,6 @@ enum class WeaponStat : uint8
 	ReloadTime
 };
 
-USTRUCT(BlueprintType)
-struct FStatModifier
-{
-	GENERATED_USTRUCT_BODY()
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	WeaponStat Stat;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	float Modifier;
-};
-
 /**
  *  Holds information about a generic component and the stats it modifies.
  */
@@ -39,5 +27,5 @@ public:
 	FString Name;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	TArray<FStatModifier> Modifiers;
+	TMap<WeaponStat, float> Modifiers;
 };

--- a/Source/UntitledGame/ItemSpawner.cpp
+++ b/Source/UntitledGame/ItemSpawner.cpp
@@ -61,11 +61,15 @@ void AItemSpawner::SpawnItem()
 
             if (UBoolProperty* RandomizeStatsProp = FindField<UBoolProperty>(ActorClass, FName("RandomizeStats")))
             {
-                UE_LOG(LogTemp, Warning, TEXT("RandomizeStatsProp found"));
                 RandomizeStatsProp->SetPropertyValue_InContainer(SpawnedWeapon, RandomizeStats);
                 OnItemSpawned.Broadcast();
             }
         }
+    }
+    else if (ItemType == ItemType::Component && ComponentItemBlueprint)
+    {
+        AActor* SpawnedComponent = GetWorld()->SpawnActor<AActor>(ComponentItemBlueprint, Location, Rotation, SpawnParams);
+        SpawnedComponent->SetOwner(this);
     }
 }
 

--- a/Source/UntitledGame/ItemSpawner.cpp
+++ b/Source/UntitledGame/ItemSpawner.cpp
@@ -14,13 +14,13 @@ AItemSpawner::AItemSpawner()
 void AItemSpawner::BeginPlay()
 {
     Super::BeginPlay();
-	SpawnItem();
+    SpawnItem();
 
 }
 
 void AItemSpawner::SpawnItem()
 {
-	FActorSpawnParameters SpawnParams;
+    FActorSpawnParameters SpawnParams;
     SpawnParams.Owner = this;
     SpawnParams.Instigator = GetInstigator();
 
@@ -28,40 +28,40 @@ void AItemSpawner::SpawnItem()
     FRotator Rotation = GetActorRotation();
 
     if (ItemType == ItemType::Ability && AbilityItemBlueprint)
-	{
-		AActor* SpawnedAbility = GetWorld()->SpawnActor<AActor>(AbilityItemBlueprint, Location, Rotation, SpawnParams);
-		SpawnedAbility->SetOwner(this);
-		if (SpawnedAbility)
-		{
-			UClass* ActorClass = SpawnedAbility->GetClass();
+    {
+        AActor* SpawnedAbility = GetWorld()->SpawnActor<AActor>(AbilityItemBlueprint, Location, Rotation, SpawnParams);
+        SpawnedAbility->SetOwner(this);
+        if (SpawnedAbility)
+        {
+            UClass* ActorClass = SpawnedAbility->GetClass();
 
-			if (UObjectProperty* AbilityClassProp = FindField<UObjectProperty>(ActorClass, FName("AbilityClass")))
-			{
-				AActor* CurrentAbilityClassValue = Cast<AActor>(AbilityClassProp->GetObjectPropertyValue_InContainer(SpawnedAbility));
-				AbilityClassProp->SetObjectPropertyValue_InContainer(SpawnedAbility, AbilityType);
-			}
-		}
-	}
+            if (UObjectProperty* AbilityClassProp = FindField<UObjectProperty>(ActorClass, FName("AbilityClass")))
+            {
+                AActor* CurrentAbilityClassValue = Cast<AActor>(AbilityClassProp->GetObjectPropertyValue_InContainer(SpawnedAbility));
+                AbilityClassProp->SetObjectPropertyValue_InContainer(SpawnedAbility, AbilityType);
+            }
+        }
+    }
     else if (ItemType == ItemType::WeaponCore && WeaponItemDebugBlueprint)
     {
         AActor* SpawnedWeapon = GetWorld()->SpawnActor<AActor>(WeaponItemDebugBlueprint, Location, Rotation, SpawnParams);
-		SpawnedWeapon->SetOwner(this);
+        SpawnedWeapon->SetOwner(this);
         if (SpawnedWeapon)
         {
             UWeaponCore* WeaponCoreComponent = Cast<UWeaponCore>(SpawnedWeapon->GetComponentByClass(UWeaponCore::StaticClass()));
             if (WeaponCoreComponent && !RandomizeStats)
             {
                 // Setting static stats if RandomizeStats is false
-                WeaponCoreComponent->FireRate = FireRate;
-                WeaponCoreComponent->ReloadTime = ReloadTime;
-                WeaponCoreComponent->MaxAbilities = MaxAbility;
+                WeaponCoreComponent->Stats[WeaponStat::FireRate] = FireRate;
+                WeaponCoreComponent->Stats[WeaponStat::ReloadTime] = ReloadTime;
+                WeaponCoreComponent->Stats[WeaponStat::MaxAbilities] = MaxAbility;
             }
 
             UClass* ActorClass = SpawnedWeapon->GetClass();
 
             if (UBoolProperty* RandomizeStatsProp = FindField<UBoolProperty>(ActorClass, FName("RandomizeStats")))
             {
-                UE_LOG(LogTemp, Warning , TEXT("RandomizeStatsProp found"));
+                UE_LOG(LogTemp, Warning, TEXT("RandomizeStatsProp found"));
                 RandomizeStatsProp->SetPropertyValue_InContainer(SpawnedWeapon, RandomizeStats);
                 OnItemSpawned.Broadcast();
             }

--- a/Source/UntitledGame/ItemSpawner.h
+++ b/Source/UntitledGame/ItemSpawner.h
@@ -13,7 +13,8 @@ UENUM(BlueprintType)
 enum class ItemType : uint8
 {
     WeaponCore UMETA(DisplayName = "WeaponCore"),
-    Ability UMETA(DisplayName = "Ability")
+    Ability UMETA(DisplayName = "Ability"),
+    Component UMETA(DisplayName = "Component")
 };
 
 UCLASS()
@@ -21,7 +22,7 @@ class UNTITLEDGAME_API AItemSpawner : public AActor
 {
     GENERATED_BODY()
 
-public:	
+public:
     // Sets default values for this actor's properties
     AItemSpawner();
 
@@ -47,23 +48,26 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ItemSpawning", meta = (EditCondition = "ItemType == ItemType::Ability"))
     TSubclassOf<AActor> AbilityType;
 
-	UPROPERTY(EditAnywhere, Category = "Blueprints")
+    UPROPERTY(EditAnywhere, Category = "Blueprints")
     TSubclassOf<AActor> AbilityItemBlueprint;
 
     UPROPERTY(EditAnywhere, Category = "Blueprints")
     TSubclassOf<AActor> WeaponItemDebugBlueprint;
 
+    UPROPERTY(EditAnywhere, Category = "Blueprints")
+    TSubclassOf<AActor> ComponentItemBlueprint;
+
     UPROPERTY(EditAnywhere, Category = "Respawning")
     float RespawnTime = 2.0f;
 
-	UFUNCTION(BlueprintCallable)
-	void RespawnItem();
+    UFUNCTION(BlueprintCallable)
+    void RespawnItem();
 
 protected:
     // Called when the game starts or when spawned
     virtual void BeginPlay() override;
-	void SpawnItem();
+    void SpawnItem();
 
-public:	
+public:
 
 };

--- a/Source/UntitledGame/PlayerCharacter.cpp
+++ b/Source/UntitledGame/PlayerCharacter.cpp
@@ -72,9 +72,9 @@ void APlayerCharacter::OnFire()
 
 void APlayerCharacter::PrintCoreStats()
 {
-	UE_LOG(Player, Warning, TEXT("MaxAbilities: %d\n"), WeaponCore->MaxAbilities);
-	UE_LOG(Player, Warning, TEXT("FireRate: %f\n"), WeaponCore->FireRate);
-	UE_LOG(Player, Warning, TEXT("ReloadTime: %f\n"), WeaponCore->ReloadTime);
+	UE_LOG(Player, Warning, TEXT("MaxAbilities: %f\n"), WeaponCore->Stats[WeaponStat::MaxAbilities]);
+	UE_LOG(Player, Warning, TEXT("FireRate: %f\n"), WeaponCore->Stats[WeaponStat::FireRate]);
+	UE_LOG(Player, Warning, TEXT("ReloadTime: %f\n"), WeaponCore->Stats[WeaponStat::ReloadTime]);
 }
 
 

--- a/Source/UntitledGame/WeaponCore.cpp
+++ b/Source/UntitledGame/WeaponCore.cpp
@@ -12,11 +12,6 @@ UWeaponCore::UWeaponCore()
 	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
 	// off to improve performance if you don't need them.
 	PrimaryComponentTick.bCanEverTick = true;
-
-	// TODO: DELETE!
-	ConstructorHelpers::FObjectFinder<UComponent> test(TEXT("Component'/Game/DataAssets/DA_TestComponent.DA_TestComponent'"));
-	if (test.Succeeded())
-		TestComponent = test.Object;
 }
 
 void UWeaponCore::BeginPlay()
@@ -38,8 +33,6 @@ void UWeaponCore::GenerateStats(int level)
 	Stats[WeaponStat::FireRate] = dis(gen);
 	std::uniform_real_distribution<> dis2(0.5f, 1.0f);
 	Stats[WeaponStat::ReloadTime] = dis2(gen);
-
-	AddComponent(TestComponent);
 }
 
 #pragma region Abilities
@@ -111,9 +104,19 @@ void UWeaponCore::AddComponent(UComponent* Component)
 	Components.Add(Component);
 }
 
+// TODO: TEST THIS METHOD!
 void UWeaponCore::RemoveComponent(UComponent* Component)
 {
+	if (!Component) return;
 
+	if (!Components.Contains(Component))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("WeaponCore: Cannot remove Component that has not been already added!"));
+		return;
+	}
+
+	ApplyComponentModifiers(Component, false);
+	Components.Remove(Component);
 }
 
 void UWeaponCore::ApplyComponentModifiers(UComponent* Component, bool isAdded)

--- a/Source/UntitledGame/WeaponCore.h
+++ b/Source/UntitledGame/WeaponCore.h
@@ -20,15 +20,12 @@ public:
 	// Sets default values for this component's properties
 	UWeaponCore();
 
-	// UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
-	// TArray<FStatValue> Stats;
-
 	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
-	int MaxAbilities;
-	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
-	float FireRate;
-	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
-	float ReloadTime;
+	TMap<WeaponStat, float> Stats{
+		{WeaponStat::MaxAbilities, 0.0f}, // Should be an integer!
+		{WeaponStat::FireRate, 0.0f},
+		{WeaponStat::ReloadTime, 0.0f}
+	};
 
 	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
 	float CurrentReloadTimeLeft;

--- a/Source/UntitledGame/WeaponCore.h
+++ b/Source/UntitledGame/WeaponCore.h
@@ -42,7 +42,7 @@ public:
 	void ShotTimerExpired();
 
 #pragma region Components
-	UComponent* TestComponent = nullptr;
+	UFUNCTION(BlueprintCallable)
 	void AddComponent(UComponent* Component);
 	void RemoveComponent(UComponent* Component);
 

--- a/Source/UntitledGame/WeaponCore.h
+++ b/Source/UntitledGame/WeaponCore.h
@@ -6,6 +6,8 @@
 #include "Components/ActorComponent.h"
 #include "UntitledGameProjectile.h"
 #include "Blueprint/UserWidget.h"
+#include "Component.h"
+
 #include "WeaponCore.generated.h"
 
 
@@ -18,12 +20,16 @@ public:
 	// Sets default values for this component's properties
 	UWeaponCore();
 
+	// UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
+	// TArray<FStatValue> Stats;
+
 	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
 	int MaxAbilities;
 	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
 	float FireRate;
 	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
 	float ReloadTime;
+
 	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
 	float CurrentReloadTimeLeft;
 	bool bCanFire;

--- a/Source/UntitledGame/WeaponCore.h
+++ b/Source/UntitledGame/WeaponCore.h
@@ -30,21 +30,34 @@ public:
 	UPROPERTY(Category = WeaponSystem, EditAnywhere, BlueprintReadWrite)
 	float CurrentReloadTimeLeft;
 	bool bCanFire;
-
+#pragma region Abilities
 	UFUNCTION(BlueprintCallable)
 	void GenerateStats(int level);
 	UFUNCTION(BlueprintCallable)
 	void AddAbility(TSubclassOf<AActor> AbilityClass);
 	void RemoveAbility(AUntitledGameProjectile* Ability);
 	void ActivateAbitlity(FVector SpawnLocation, FRotator SpawnRotation, AActor* OwningActor);
+#pragma endregion Abilities
+
 	void ShotTimerExpired();
 
+#pragma region Components
+	UComponent* TestComponent = nullptr;
+	void AddComponent(UComponent* Component);
+	void RemoveComponent(UComponent* Component);
+
+	// Updates current WeaponCore stats. {isAdded} - indicates if the Component modifiers should be added or removed
+	void ApplyComponentModifiers(UComponent* Component, bool isAdded);
+#pragma endregion Components
 
 private:
 	int PlayerLevel;
 	int AbilityIndex;
 	TArray<TSubclassOf<AActor>> AbilitiesClasses;
 	FTimerHandle TimerHandle_ReloadTimeDecrement;
+
+	UPROPERTY(Category = WeaponSystem, VisibleAnywhere)
+	TSet<UComponent*> Components;
 
 	void DecrementReloadTime();
 protected:


### PR DESCRIPTION
Story ID: 7
- Added UComponent : DataAsset that holds information about a Component (similar to Scriptable Objects in Unity)|
- Added WeaponStat enum in UComponent 
- All relevant classes now use WeaponStat enum instead of loose variables
- WeaponCore now holds methods for Adding and Removing a component (removing is not tested yet!) and a TSet of all added components
- Added BP_ComponentItem and integrated it in ItemSpawner to be able to spawn a pick-up for a TestComponent
-  On pick-up the Player's Weapon Core Stats are modified by the Component (can be checked by inspecting it in the editor)